### PR TITLE
This is neccessary for when you use something like spacewalk/satellit…

### DIFF
--- a/tasks/setup-RedHat.yml
+++ b/tasks/setup-RedHat.yml
@@ -18,6 +18,7 @@
   rpm_key:
     state: present
     key: "{{ jenkins_repo_key_url }}"
+  when: jenkins_repo_url != ""
 
 - name: Download specific Jenkins version.
   get_url:


### PR DESCRIPTION
…e and specify "jenkins_repo_key_url=" that it does not fail trying to add a GPG key